### PR TITLE
Allow custom kibit rules

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,5 +3,6 @@
   :url "https://github.com/jonase/lein-kibit"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[jonase/kibit "0.1.1-SNAPSHOT"]]
+  :dependencies [[jonase/kibit "0.1.2"]
+                 [org.clojure/tools.namespace "0.2.11"]]
   :eval-in-leiningen true)

--- a/src/leiningen/kibit.clj
+++ b/src/leiningen/kibit.clj
@@ -9,10 +9,11 @@
   (let [src-paths (get-in project [:kibit :source-paths] ["rules"])
         kibit-project `{:dependencies [[jonase/kibit "0.1.2"]]
                         :source-paths ~src-paths}
-        paths (seq (disj (set (concat (:source-paths project)
-                                      [(:source-path project)]
-                                      (mapcat :source-paths (get-in project [:cljsbuild :builds]))
-                                      (mapcat :source-paths (get-in project [:cljx :builds]))))
+        paths (seq (disj (set (concat
+                               (:source-paths project)
+                               [(:source-path project)]
+                               (mapcat :source-paths (get-in project [:cljsbuild :builds]))
+                               (mapcat :source-paths (get-in project [:cljx :builds]))))
                          nil))
         rules (get-in project [:kibit :rules])
         src `(kibit.driver/external-run '~paths

--- a/src/leiningen/kibit.clj
+++ b/src/leiningen/kibit.clj
@@ -1,17 +1,28 @@
 (ns leiningen.kibit
-  (:require [leiningen.core.eval :refer [eval-in-project]]))
+  (:require [leiningen.core.eval :refer [eval-in-project]]
+            [clojure.tools.namespace.find :refer [find-namespaces]])
+  (:import [java.io File]))
+
 
 (defn ^:no-project-needed kibit
   [project & args]
-  (let [kibit-project '{:dependencies [[jonase/kibit "0.0.9-SNAPSHOT"]]}
-        paths (seq (disj (set (concat
-                                (:source-paths project)
-                                [(:source-path project)]
-                                (mapcat :source-paths (get-in project [:cljsbuild :builds]))
-                                (mapcat :source-paths (get-in project [:cljx :builds]))))
+  (let [src-paths (get-in project [:kibit :source-paths] ["rules"])
+        kibit-project `{:dependencies [[jonase/kibit "0.1.2"]]
+                        :source-paths ~src-paths}
+        paths (seq (disj (set (concat (:source-paths project)
+                                      [(:source-path project)]
+                                      (mapcat :source-paths (get-in project [:cljsbuild :builds]))
+                                      (mapcat :source-paths (get-in project [:cljx :builds]))))
                          nil))
-        src `(kibit.driver/external-run '~paths ~@args)
-        req '(require 'kibit.driver)]
+        rules (get-in project [:kibit :rules])
+        src `(kibit.driver/external-run '~paths
+                                        (when ~rules
+                                          (apply concat (vals ~rules)))
+                                        ~@args)
+        ns-xs (mapcat identity (map #(find-namespaces [(File. %)]) src-paths))
+        req `(do (require 'kibit.driver)
+                 (doseq [n# '~ns-xs]
+                   (require n#)))]
     (try (eval-in-project kibit-project src req)
          (catch Exception e
            (throw (ex-info "" {:exit-code 1}))))))


### PR DESCRIPTION
project.clj will need to have following entry

```
:kibit {:rules (merge kibit.rules/rule-map
                      {:ctrl test/rules})
        :source-paths ["rules"]}
```

All namespaces found in source-paths dir will be required during kibit
run.

Update kibit version in project.clj and 'kibit-project'

This change is dependent on a change in kibit. https://github.com/jonase/kibit/pull/139

We will have to follow these steps to push a new version of lein-kibit
- Merge pull request #139 on kibit and release a new version
- Update this pull request pointing to latest kibit, merge pull request and release lein-kibit